### PR TITLE
Fix System.IndexOutOfRangeException

### DIFF
--- a/OsuLiveStatusPanel/PPShow/Beatmap/BeatmapParser.cs
+++ b/OsuLiveStatusPanel/PPShow/Beatmap/BeatmapParser.cs
@@ -55,6 +55,12 @@ namespace OsuLiveStatusPanel.PPShow.Beatmap
                 while (!reader.EndOfStream)
                 {
                     string line = reader.ReadLine();
+
+                    if (line.Contains("[") && status != 0)
+                    {
+                        status = 0;
+                    }
+
                     switch (status)
                     {
                         case 0: //seeking


### PR DESCRIPTION
Typically, the .osu file consists of the following:
```
[General]
...

[Editor]
...

[Metadata]
...

[Events]
...

[TimingPoints]
...

[Colours]
...

[HitObjects]
...
```

However, some files may not have a new line between sections. as below:
```
[TimingPoints]
...
132749,-57.1428571428571,4,3,1,60,0,0
142966,-100,4,3,1,5,0,0
143128,-400,4,3,1,60,0,0
[Colours]
Combo1 : 172,172,172
Combo2 : 255,125,0
Combo3 : 225,0,0
Combo4 : 255,200,0
```

In this situation, unintended behavior may occur.
For example, There is no new line between the `TimingPoints` and `HitObjects` section:
```
[TimingPoints]
221068,-200,3,2,1,65,0,0
221154,-200,3,2,1,5,0,0
[HitObjects]
96,119,234,70,0,P|110:180|120:256,1,131.25000500679,2|2,0:0|0:1,0:0:0:0:
206,279,755,2,0,P|214:213|229:150,1,131.25000500679,2|2,0:0|0:1,0:0:0:0:
```

`reader.ReadLine()` puts `[HitObjects]` in `line`:

```csharp
//@@ -136,7 +136,7 @@ public static void ParseBeatmap(ref byte[] beatmap_raw_data, Dictionary<string,
//line = "[HitObjects]"
case 2: //TimingPoints
  if (string.IsNullOrWhiteSpace(line)) //pass through
  {
    ...
  }

  bool is_red_line = true;
  string[] data = line.Split(',');
  //data = {"[HitObjects]"}

  if (data.Length >= 7) //pass through
  {
    if (data[6] == "1" || string.IsNullOrWhiteSpace(data[6]))
      is_red_line = true;
    else
      is_red_line = false;
  }

  if (!is_red_line) break;//pass through

  double val = double.Parse(data[1], CultureInfo.InvariantCulture);
  //data[1] is Out of Array, it throws System.IndexOutOfRangeException

```

So, i added a phrase to check if contains `[`.
**EDIT:** Code cleanup